### PR TITLE
Better handle double[] and int[]

### DIFF
--- a/src/test/java/qupath/bioimageio/spec/TestBioImageIoSpec.java
+++ b/src/test/java/qupath/bioimageio/spec/TestBioImageIoSpec.java
@@ -8,10 +8,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+/**
+ * Test parsing the spec.
+ */
 class TestBioImageIoSpec {
 	
 	static List<Path> provideYamlPaths() throws IOException, URISyntaxException {
@@ -30,7 +36,7 @@ class TestBioImageIoSpec {
 			.filter(TestBioImageIoSpec::isModelYaml)
 			.collect(Collectors.toList());
 		} else {
-			System.err.println("To yaml files found to test!");
+			System.err.println("No yaml files found to test!");
 			return Collections.emptyList();
 		}
 	}
@@ -45,6 +51,10 @@ class TestBioImageIoSpec {
 		return false;
 	}
 
+	/**
+	 * Test that the model in a specific path can be parsed.
+	 * @param path
+	 */
 	@ParameterizedTest
 	@MethodSource("provideYamlPaths")
 	void testParseSpec(Path path) {
@@ -55,6 +65,17 @@ class TestBioImageIoSpec {
 		} catch (IOException e) {
 			fail(e);
 		}
+	}
+	
+	
+	/**
+	 * Test creating shapes for different axes strings.
+	 */
+	@Test
+	void testCreateShape() {
+		assertArrayEquals(new int[]{1, 512, 256, 1}, BioimageIoSpec.createShapeArray("byxc", Map.of('x', 256, 'y', 512), 1));
+		assertArrayEquals(new int[]{256, 512, -1}, BioimageIoSpec.createShapeArray("xyc", Map.of('x', 256, 'y', 512), -1));
+		assertArrayEquals(new int[]{3, 4, 5, 6}, BioimageIoSpec.createShapeArray("xyct", Map.of('x', 3, 'y', 4, 'c', 5, 't', 6), -1));
 	}
 	
 	


### PR DESCRIPTION
* Cope with `[-inf, inf]` input, even when `[-.inf, .inf]` is expected
* Create helper methods for dealing with shapes of different kinds