### PR TITLE
Remove separate input/output axes

### DIFF
--- a/src/main/java/qupath/bioimageio/spec/tensor/axes/Axes.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/axes/Axes.java
@@ -55,7 +55,7 @@ public class Axes {
                 }
                 return axes;
             }
-            // todo: input or output???
+            // todo: handle separate input or output axis types if needed
             if (jsonElement.isJsonArray()) {
                 var arr = jsonElement.getAsJsonArray();
                 Axis[] axes = new Axis[arr.size()];
@@ -71,15 +71,13 @@ public class Axes {
                     var desc = deserializeField(context, oj, "description", String.class, "");
                     Size size = deserializeSize(context, oj.get("size"), oj.get("scale"));
                     switch (oj.get("type").getAsString()) {
-                        case "time":
-                            axes[i] = new TimeAxes.TimeInputAxis(
-                                    id, desc,
-                                    TimeAxes.TimeUnit.valueOf(oj.get("unit").getAsString().toUpperCase()),
-                                    oj.get("scale").getAsDouble(),
-                                    size
-                            );
-                            break;
-                        case "channel":
+                        case "time" -> axes[i] = new TimeAxes.TimeAxis(
+                                id, desc,
+                                TimeAxes.TimeUnit.valueOf(oj.get("unit").getAsString().toUpperCase()),
+                                oj.get("scale").getAsDouble(),
+                                size
+                        );
+                        case "channel" -> {
                             var namesJSON = oj.get("channel_names").getAsJsonArray();
                             List<String> names = new LinkedList<>();
                             for (JsonElement n : namesJSON) {
@@ -89,24 +87,20 @@ public class Axes {
                                     id, desc,
                                     names
                             );
-                            break;
-                        case "index":
-                            axes[i] = new IndexAxes.IndexInputAxis(id, desc, size);
-                            break;
-                        case "space":
-                            axes[i] = new SpaceAxes.SpaceInputAxis(
-                                    id, desc,
-                                    deserializeField(context, oj, "unit", String.class, ""),
-                                    deserializeField(context, oj, "scale", Double.class, 1.0),
-                                    size
-                            );
-                            break;
-                        case "batch":
-                            axes[i] = new BatchAxis(id, desc, deserializeField(context, oj, "size", Integer.class, 1));
-                            break;
-                        default:
+                        }
+                        case "index" -> axes[i] = new IndexAxes.IndexAxis(id, desc, size);
+                        case "space" -> axes[i] = new SpaceAxes.SpaceAxis(
+                                id, desc,
+                                deserializeField(context, oj, "unit", String.class, ""),
+                                deserializeField(context, oj, "scale", Double.class, 1.0),
+                                size
+                        );
+                        case "batch" ->
+                                axes[i] = new BatchAxis(id, desc, deserializeField(context, oj, "size", Integer.class, 1));
+                        default -> {
                             logger.error("Unknown object {}", oj);
                             axes[i] = null;
+                        }
                     }
                 }
                 return axes;

--- a/src/main/java/qupath/bioimageio/spec/tensor/axes/Axes.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/axes/Axes.java
@@ -70,8 +70,8 @@ public class Axes {
                     var id = deserializeField(context, oj, "id", String.class, "");
                     var desc = deserializeField(context, oj, "description", String.class, "");
                     Size size = deserializeSize(context, oj.get("size"), oj.get("scale"));
-                    switch (oj.get("type").getAsString()) {
-                        case "time" -> axes[i] = new TimeAxes.TimeAxis(
+                    axes[i] = switch (oj.get("type").getAsString()) {
+                        case "time" -> new TimeAxes.TimeAxis(
                                 id, desc,
                                 TimeAxes.TimeUnit.valueOf(oj.get("unit").getAsString().toUpperCase()),
                                 oj.get("scale").getAsDouble(),
@@ -83,25 +83,24 @@ public class Axes {
                             for (JsonElement n : namesJSON) {
                                 names.add(n.getAsString());
                             }
-                            axes[i] = new ChannelAxis(
+                            yield new ChannelAxis(
                                     id, desc,
                                     names
                             );
                         }
-                        case "index" -> axes[i] = new IndexAxes.IndexAxis(id, desc, size);
-                        case "space" -> axes[i] = new SpaceAxes.SpaceAxis(
+                        case "index" -> new IndexAxes.IndexAxis(id, desc, size);
+                        case "space" -> new SpaceAxes.SpaceAxis(
                                 id, desc,
                                 deserializeField(context, oj, "unit", String.class, ""),
                                 deserializeField(context, oj, "scale", Double.class, 1.0),
                                 size
                         );
-                        case "batch" ->
-                                axes[i] = new BatchAxis(id, desc, deserializeField(context, oj, "size", Integer.class, 1));
+                        case "batch" -> new BatchAxis(id, desc, deserializeField(context, oj, "size", Integer.class, 1));
                         default -> {
                             logger.error("Unknown object {}", oj);
-                            axes[i] = null;
+                            yield null;
                         }
-                    }
+                    };
                 }
                 return axes;
             }

--- a/src/main/java/qupath/bioimageio/spec/tensor/axes/IndexAxes.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/axes/IndexAxes.java
@@ -44,11 +44,11 @@ public class IndexAxes {
         }
     }
 
-    static class IndexInputAxis extends IndexAxisBase {
+    static class IndexAxis extends IndexAxisBase {
         private final Size size;
         private final boolean concatenable = false;
 
-        IndexInputAxis(String id, String description, Size size) {
+        IndexAxis(String id, String description, Size size) {
             super(id, description);
             this.size = size;
         }
@@ -63,21 +63,4 @@ public class IndexAxes {
         }
     }
 
-    static class IndexOutputAxis extends IndexAxisBase {
-        private Size size;
-
-        IndexOutputAxis(String id, String description) {
-            super(id, description);
-        }
-
-        @Override
-        public Size getSize() {
-            return size;
-        }
-
-        @Override
-        public void validate(List<? extends BaseTensor> tensors) {
-            size.validate(tensors);
-        }
-    }
 }

--- a/src/main/java/qupath/bioimageio/spec/tensor/axes/SpaceAxes.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/axes/SpaceAxes.java
@@ -109,11 +109,11 @@ public class SpaceAxes {
         }
     }
 
-    static class SpaceInputAxis extends SpaceAxisBase {
+    static class SpaceAxis extends SpaceAxisBase {
         private final Size size;
         private final boolean concatenable = false;
 
-        SpaceInputAxis(String id, String description, String unit, double scale, Size size) {
+        SpaceAxis(String id, String description, String unit, double scale, Size size) {
             super(id, description, unit.isEmpty() ? "NO_UNIT" : unit, scale);
             this.size = size;
         }
@@ -129,30 +129,13 @@ public class SpaceAxes {
         }
     }
 
-    static class SpaceOutputAxis extends SpaceAxisBase {
-        private final Size size;
 
-        SpaceOutputAxis(String id, String description, String unit, double scale, Size size) {
-            super(id, description, unit, scale);
-            this.size = size;
-        }
 
-        @Override
-        public Size getSize() {
-            return this.size;
-        }
-
-        @Override
-        public void validate(List<? extends BaseTensor> tensors) {
-            getSize().validate(tensors);
-        }
-    }
-
-    static class SpaceOutputAxisWithHalo extends SpaceOutputAxis implements WithHalo {
+    static class SpaceAxisWithHalo extends SpaceAxis implements WithHalo {
         private ReferencedSize size;
         private final int halo;
 
-        SpaceOutputAxisWithHalo(String id, String description, String unit, double scale, Size size, int halo) {
+        SpaceAxisWithHalo(String id, String description, String unit, double scale, Size size, int halo) {
             super(id, description, unit, scale, size);
             this.halo = halo;
         }

--- a/src/main/java/qupath/bioimageio/spec/tensor/axes/TimeAxes.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/axes/TimeAxes.java
@@ -51,10 +51,10 @@ public class TimeAxes {
         }
     }
 
-    static class TimeInputAxis extends TimeAxisBase {
+    static class TimeAxis extends TimeAxisBase {
         private final Size size;
 
-        TimeInputAxis(String id, String description, TimeUnit unit, double scale, Size size) {
+        TimeAxis(String id, String description, TimeUnit unit, double scale, Size size) {
             super(id, description, unit, scale);
             this.size = size;
         }
@@ -70,29 +70,10 @@ public class TimeAxes {
         }
     }
 
-    static class TimeOutputAxis extends TimeAxisBase {
-        private final Size size;
-
-        TimeOutputAxis(String id, String description, TimeUnit unit, double scale, Size size) {
-            super(id, description, unit, scale);
-            this.size = size;
-        }
-
-        @Override
-        public Size getSize() {
-            return size;
-        }
-
-        @Override
-        public void validate(List<? extends BaseTensor> tensors) {
-            getSize().validate(tensors);
-        }
-    }
-
-    static class TimeOutputAxisWithHalo extends TimeOutputAxis implements WithHalo {
+    static class TimeAxisWithHalo extends TimeAxis implements WithHalo {
         private final int halo;
 
-        TimeOutputAxisWithHalo(String id, String description, TimeUnit unit, double scale, Size size, int halo) {
+        TimeAxisWithHalo(String id, String description, TimeUnit unit, double scale, Size size, int halo) {
             super(id, description, unit, scale, size);
             this.halo = halo;
         }


### PR DESCRIPTION
There's not any functional difference at the moment, so this simplifies the code and means we can't have output axes on an input tensor or vice versa