### PR TITLE
Add min method to size interface

### DIFF
--- a/src/main/java/qupath/bioimageio/spec/tensor/Shape.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/Shape.java
@@ -20,13 +20,13 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
+import qupath.bioimageio.spec.tensor.sizes.ParameterizedSize;
 import qupath.bioimageio.spec.tensor.sizes.Size;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 /**
@@ -268,12 +268,12 @@ public class Shape {
 
         SizesShape(List<Size> sizes) {
             this.sizes = sizes;
-            this.shape = this.sizes.stream().mapToInt(Size::getSize).toArray();
+            this.shape = this.sizes.stream().mapToInt(Size::size).toArray();
         }
 
         @Override
         public int[] getShape() {
-            return sizes.stream().mapToInt(Size::getSize).toArray();
+            return sizes.stream().mapToInt(Size::size).toArray();
         }
 
         @Override
@@ -281,6 +281,13 @@ public class Shape {
             assert target.length == sizes.size();
             return IntStream.range(0, target.length)
                     .map(i -> sizes.get(i).getTargetSize(target[i]))
+                    .toArray();
+        }
+
+        @Override
+        public int[] getShapeMin() {
+            return sizes.stream()
+                    .mapToInt(s -> s == null ? 0 : s.getMin())
                     .toArray();
         }
 
@@ -317,5 +324,3 @@ public class Shape {
     }
 
 }
-
-

--- a/src/main/java/qupath/bioimageio/spec/tensor/TensorDataDescription.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/TensorDataDescription.java
@@ -1,21 +1,5 @@
 package qupath.bioimageio.spec.tensor;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 /**
  * Descriptions of tensor data types, primarily ratio types or nominal/ordinal types represented by int-like numeric values.
  */

--- a/src/main/java/qupath/bioimageio/spec/tensor/sizes/DataDependentSize.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/sizes/DataDependentSize.java
@@ -34,18 +34,23 @@ class DataDependentSize implements Size {
     }
 
     @Override
-    public int getSize() {
+    public int size() {
         return NO_SIZE;
     }
 
     @Override
     public int getTargetSize(int target) {
-        return getSize();
+        return size();
     }
 
     @Override
     public int getStep() {
         return NO_SIZE;
+    }
+
+    @Override
+    public int getMin() {
+        return min;
     }
 
     @Override

--- a/src/main/java/qupath/bioimageio/spec/tensor/sizes/FixedSize.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/sizes/FixedSize.java
@@ -23,30 +23,28 @@ import java.util.List;
 /**
  * A fixed axis size. Basically an int with extra steps.
  */
-public class FixedSize implements Size {
-    private final int size;
-
+public record FixedSize(int size) implements Size {
     /**
      * Create a fixed size instance
+     *
      * @param size The fixed size in pixels.
      */
-    public FixedSize(int size) {
-        this.size = size;
-    }
-
-    @Override
-    public int getSize() {
-        return size;
+    public FixedSize {
     }
 
     @Override
     public int getTargetSize(int target) {
-        return getSize();
+        return size();
     }
 
     @Override
     public int getStep() {
         return NO_SIZE;
+    }
+
+    @Override
+    public int getMin() {
+        return size();
     }
 
     @Override

--- a/src/main/java/qupath/bioimageio/spec/tensor/sizes/ParameterizedSize.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/sizes/ParameterizedSize.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * Describes a range of valid tensor axis sizes as `size = min + n*step`.
  */
-class ParameterizedSize implements Size {
+public class ParameterizedSize implements Size {
     private final int min;
     private final int step;
 
@@ -33,7 +33,7 @@ class ParameterizedSize implements Size {
     }
 
     @Override
-    public int getSize() {
+    public int size() {
         return getTargetSize(1);
     }
 
@@ -44,9 +44,16 @@ class ParameterizedSize implements Size {
         else
             return min + (int)Math.round((target - min)/(double)step) * step;
     }
+
     @Override
     public int getStep() {
         return step;
+    }
+
+
+    @Override
+    public int getMin() {
+        return min;
     }
 
     @Override

--- a/src/main/java/qupath/bioimageio/spec/tensor/sizes/ReferencedSize.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/sizes/ReferencedSize.java
@@ -48,18 +48,23 @@ public class ReferencedSize implements Size {
     }
 
     @Override
-    public int getSize() {
-        return (int) (referenceAxis.getSize().getSize() * referenceAxis.getScale() / scale + offset);
+    public int size() {
+        return (int) (referenceAxis.getSize().size() * referenceAxis.getScale() / scale + offset);
     }
 
     @Override
     public int getTargetSize(int target) {
-        return getSize();
+        return size();
     }
 
     @Override
     public int getStep() {
         return NO_SIZE;
+    }
+
+    @Override
+    public int getMin() {
+        return size();
     }
 
     @Override

--- a/src/main/java/qupath/bioimageio/spec/tensor/sizes/Size.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/sizes/Size.java
@@ -44,7 +44,7 @@ public interface Size {
      * Get the default size of this axis. {@link #getTargetSize(int)} may be more useful.
      * @return The size of this axis.
      */
-    int getSize();
+    int size();
 
     /**
      * Get a size as close as possible to a target.
@@ -58,6 +58,12 @@ public interface Size {
      * @return {@link #NO_SIZE} for any axis without a step size, otherwise the size.
      */
     int getStep();
+
+    /**
+     * Gets the minimum shape for this axis.
+     * @return the minimum size in pixels
+     */
+    int getMin();
 
     /**
      * Validate a tensor's size, ensuring that all internal fields are valid and resolving links between tensor objects.

--- a/src/test/java/qupath/bioimageio/spec/TestBioImageIoSpec.java
+++ b/src/test/java/qupath/bioimageio/spec/TestBioImageIoSpec.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 import static qupath.bioimageio.spec.Model.findModelRdf;
 import static qupath.bioimageio.spec.Model.isYamlPath;
-import static qupath.bioimageio.spec.Model.parse;
 import static qupath.bioimageio.spec.tensor.Shape.createShapeArray;
 
 /**


### PR DESCRIPTION
Our use of `Shape` and `Size` objects relies heavily on these having a `min`; each of the size classes has a fairly well-defined `min`, therefore rather than relying on calling code to check the shape or target shape, it is easier for us to add a `min` to the `Size` interface and propagate calls from `Shape` down to the individual `Size` objects if necessary (eg, in an 0.5 object).

Also convert `FixedSize` to a record.