### PR TITLE
Bump logback and check null #23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10'
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.9.1"
-    testImplementation 'ch.qos.logback:logback-classic:1.5.16'
+    testImplementation 'ch.qos.logback:logback-classic:1.5.19'
 }
 
 processResources {

--- a/src/main/java/qupath/bioimageio/spec/tensor/Processing.java
+++ b/src/main/java/qupath/bioimageio/spec/tensor/Processing.java
@@ -221,7 +221,7 @@ public class Processing {
          * @return the subset of axes to scale jointly.
          */
         public Axis[] getAxes() {
-            return axes.clone();
+            return axes == null ? null : axes.clone();
         }
 
     }


### PR DESCRIPTION
Bump logback because of a CVE, and check for null before returning axes in processingwithmode